### PR TITLE
[BUGFIX] Correct the supported versions table

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,14 +14,16 @@ reporting an issue against them.
 
 | Version        | Supported           |
 | -------------- | ------------------- |
-| 0.x            | :x:                 |
+| 11.x           | :x:                 |
+| none.x         | :x:                 |
+| < none.0       | :x:                 |
 
-> **Note:** the newest version of this product targets a TYPO3 version that has left
-> regular LTS maintenance, so no version is currently covered by security updates.
-> Support for a newer TYPO3 version may be added in the future; if you depend on
-> this product, please get in touch through the reporting channel below.
+> **Note:** this product declares no TYPO3 version requirement, so its supported
+> versions cannot be derived from the TYPO3 release lifecycle. Support for a current
+> TYPO3 version may be added in the future; if you depend on this product, please get
+> in touch through the reporting channel below.
 
-Planned end of support for this product: **31 October 2024 (end of regular TYPO3 11 LTS support)**.
+Planned end of support for this product: **unknown (end of regular TYPO3 0 LTS support)**.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Corrects the supported-versions table.

The previous version read the TYPO3 range from the **default branch** and attributed
it to the newest **released** major. Those are different things wherever development
has moved ahead of the last release, and the result overstated what the released line
supports.

The table now distinguishes three lines — the development line on the default branch
(listed only when it is genuinely ahead of the newest release), the newest released
major, and the one before it — each judged against the TYPO3 versions that line
actually declares. A line counts as supported while the newest TYPO3 version it
supports is still under **regular** LTS maintenance per get.typo3.org: TYPO3 13 (until
2027-12-31) and 14 (until 2029-06-30) qualify; 12 and below are ELTS or end of life.

The support-end date is the LTS end of the newest TYPO3 version across the supported
lines.
